### PR TITLE
Stack Navigation

### DIFF
--- a/app/navigators/AppNavigator.tsx
+++ b/app/navigators/AppNavigator.tsx
@@ -8,14 +8,9 @@ import {
   DarkTheme,
   DefaultTheme,
   NavigationContainer,
-  NavigationHelpers,
 } from '@react-navigation/native'
-import {
-  NativeStackScreenProps,
-  createNativeStackNavigator,
-} from '@react-navigation/native-stack'
 import React from 'react'
-import {Pressable, useColorScheme, type ViewStyle} from 'react-native'
+import {useColorScheme, View, type ViewStyle} from 'react-native'
 import {GameDetailsScreen} from '../screens/GameDetailsScreen/GameDetailsScreen'
 import {GamesListScreen} from '../screens/GamesListScreen/GamesListScreen'
 import {ReviewScreen} from '../screens/ReviewScreen/ReviewScreen'
@@ -25,6 +20,7 @@ import {safeParse} from '../utils/safeParse'
 import {colors, fonts} from '../theme'
 import {Icon} from '../components/Icon'
 import {spacing12} from '../theme/tokens/sizePrimitives'
+import {StackScreenProps, createStackNavigator} from '@react-navigation/stack'
 
 export const storage = new MMKV({id: '@RNEssentials/navigation/state'})
 
@@ -51,25 +47,21 @@ export type AppStackParamList = {
 }
 
 export type AppStackScreenProps<T extends keyof AppStackParamList> =
-  NativeStackScreenProps<AppStackParamList, T>
+  StackScreenProps<AppStackParamList, T>
 
-export type ScreenProps<T extends keyof AppStackParamList> =
-  NativeStackScreenProps<AppStackParamList, T>
+export type ScreenProps<T extends keyof AppStackParamList> = StackScreenProps<
+  AppStackParamList,
+  T
+>
 
 // Documentation: https://reactnavigation.org/docs/stack-navigator/
-const Stack = createNativeStackNavigator<AppStackParamList>()
+const Stack = createStackNavigator<AppStackParamList>()
 
-const renderBackButton = (navigation: NavigationHelpers<AppStackParamList>) => {
+const renderBackButton = () => {
   return (
-    navigation.canGoBack() && (
-      <Pressable style={$backButton} onPress={() => navigation.goBack()}>
-        <Icon
-          name="arrow-left-circle"
-          size={30}
-          color={colors.tokens.textBase}
-        />
-      </Pressable>
-    )
+    <View style={$backButton}>
+      <Icon name="arrow-left-circle" size={30} color={colors.tokens.textBase} />
+    </View>
   )
 }
 
@@ -77,10 +69,13 @@ const AppStack = () => {
   return (
     <Stack.Navigator
       initialRouteName="TmpDevScreen"
-      screenOptions={({navigation}) => ({
-        headerLeft: () => renderBackButton(navigation),
+      screenOptions={{
+        headerBackImage: () => renderBackButton(),
+        headerBackTitleVisible: false,
         headerStyle: {
           backgroundColor: colors.tokens.backgroundHeaderList,
+          borderBottomColor: colors.tokens.textBase,
+          borderBottomWidth: 2,
         },
         headerTitleAlign: 'center',
         headerTintColor: colors.tokens.textBase,
@@ -88,7 +83,7 @@ const AppStack = () => {
           fontSize: 24,
           fontFamily: fonts.primary.semiBold,
         },
-      })}>
+      }}>
       <Stack.Screen
         name="TmpDevScreen"
         component={TmpDevScreen}
@@ -127,5 +122,5 @@ export const AppNavigator = (props: NavigationProps) => {
 }
 
 const $backButton: ViewStyle = {
-  marginRight: spacing12,
+  marginHorizontal: spacing12,
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
  * @format
  */
 
+import 'react-native-gesture-handler'
 import {AppRegistry} from 'react-native'
 import App from './app/App'
 import {name as appName} from './app.json'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1138,6 +1138,10 @@ PODS:
     - React-perflogger (= 0.73.1)
   - RNBootSplash (5.2.2):
     - React-Core
+  - RNGestureHandler (2.14.0):
+    - glog
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core
   - RNScreens (3.29.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1227,6 +1231,7 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNBootSplash (from `../node_modules/react-native-bootsplash`)
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -1362,6 +1367,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNBootSplash:
     :path: "../node_modules/react-native-bootsplash"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   Yoga:
@@ -1438,6 +1445,7 @@ SPEC CHECKSUMS:
   React-utils: debda2c206770ee2785bdebb7f16d8db9f18838a
   ReactCommon: ddb128564dcbfa0287d3d1a2d10f8c7457c971f6
   RNBootSplash: 6890a69d909d76076aaba018bd74bb526f82fe68
+  RNGestureHandler: 61bfdfc05db9b79dd61f894dcd29d3dcc6db3c02
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4f53dc50008d626fa679c7a1cb4bed898f8c0bde

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "@expo-google-fonts/oxanium": "^0.2.3",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
+    "@react-navigation/stack": "^6.3.20",
     "expo": ">=50.0.0-0 <51.0.0",
     "expo-font": "~11.10.0",
     "react": "18.2.0",
     "react-native": "0.73.1",
     "react-native-bootsplash": "^5.2.2",
+    "react-native-gesture-handler": "~2.14.0",
     "react-native-mmkv": "^2.11.0",
     "react-native-safe-area-context": "^4.8.2",
     "react-native-screens": "^3.29.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,6 +1215,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@egjs/hammerjs@^2.0.17":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
+  integrity sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==
+  dependencies:
+    "@types/hammerjs" "^2.0.36"
+
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -2415,6 +2422,15 @@
   dependencies:
     nanoid "^3.1.23"
 
+"@react-navigation/stack@^6.3.20":
+  version "6.3.20"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-6.3.20.tgz#8eec944888f317bb1ba1ff30e7f513806bea16c2"
+  integrity sha512-vE6mgZzOgoa5Uy7ayT97Cj+ZIK7DK+JBYVuKUViILlWZy6IWK7HFDuqoChSbZ1ajTIfAxj/acVGg1jkbAKsToA==
+  dependencies:
+    "@react-navigation/elements" "^1.3.21"
+    color "^4.2.3"
+    warn-once "^0.1.0"
+
 "@remix-run/node@^1.19.3":
   version "1.19.3"
   resolved "https://registry.yarnpkg.com/@remix-run/node/-/node-1.19.3.tgz#d27e2f742fc45379525cb3fca466a883ca06d6c9"
@@ -2578,6 +2594,11 @@
   integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
   dependencies:
     "@types/node" "*"
+
+"@types/hammerjs@^2.0.36":
+  version "2.0.45"
+  resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.45.tgz#ffa764bb68a66c08db6efb9c816eb7be850577b1"
+  integrity sha512-qkcUlZmX6c4J8q45taBKTL3p+LbITgyx7qhlPYOdOHZB7B31K0mXbP5YA7i7SgDeEGuI9MnumiKPEMrxg8j3KQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.6"
@@ -5375,6 +5396,13 @@ hermes-profile-transformer@^0.0.6:
   dependencies:
     source-map "^0.7.3"
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.8.tgz#6e35d4cc87af2c5f816e4cb9ce350ba87a3f370d"
@@ -7716,7 +7744,7 @@ prompts@^2.0.1, prompts@^2.3.2, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7818,7 +7846,7 @@ react-freeze@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-is@^16.13.0, react-is@^16.13.1:
+react-is@^16.13.0, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -7856,6 +7884,17 @@ react-native-flipper@^0.164.0:
   version "0.164.0"
   resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.164.0.tgz#64f6269a86a13a72e30f53ba9f5281d2073a7697"
   integrity sha512-iJhIe3rqx6okuzBp4AJsTa2b8VRAOGzoLRFx/4HGbaGvu8AurZjz8TTQkhJsRma8dsHN2b6KKZPvGGW3wdWzvA==
+
+react-native-gesture-handler@~2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.14.0.tgz#d6aec0d8b2e55c67557fd6107e828c0a1a248be8"
+  integrity sha512-cOmdaqbpzjWrOLUpX3hdSjsMby5wq3PIEdMq7okJeg9DmCzanysHSrktw1cXWNc/B5MAgxAn9J7Km0/4UIqKAQ==
+  dependencies:
+    "@egjs/hammerjs" "^2.0.17"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
 
 react-native-mmkv@^2.11.0:
   version "2.11.0"


### PR DESCRIPTION
### Summary

This uses `Stack` instead of `NativeStack` because it has configuration options that `NativeStack` doesn't. (e.g. `headerBackImage` so that you don't have to manage the back button yourself. It also allows for more styling options like the border at the bottom of the navigation.

Test it out and let me know which one you prefer.

### How to verify

1. `yarn`
2. `yarn start`
3. `i` & `a`

**Expected results**:

### Screenshots

| iOS                                             | Android                                             |
| ----------------------------------------------- | --------------------------------------------------- |
| <video width="300" alt="ios screenshot" src="https://github.com/infinitered/ReactNativeEssentials/assets/151139/df2b9763-4b09-43ab-b7ff-bdf0601b865b" /> | <video width="300" alt="android screenshot" src="https://github.com/infinitered/ReactNativeEssentials/assets/151139/ff4d3ae7-ddc9-40b6-9cca-dee91e5ed620" /> |
