### PR TITLE
Upgrading Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,4 +95,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.1.4
+   2.4.10


### PR DESCRIPTION
### Summary

This gets rid of a Ruby deprecation warning:
```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

### How to verify

Inside of the project directory:

1. `(cd ios && bundle exec pod install`
2. Notice there is a deprecation warning.
3. `bundle update --bundler`
4. `(cd ios && bundle exec pod install`

### Expected results

No more deprecation warning.
